### PR TITLE
Add SingLoRA adapter option

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,6 +15,58 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
+
+class LoRALinear(nn.Linear):
+    """Linear layer with Low-Rank Adaptation (LoRA)."""
+
+    def __init__(self, in_features, out_features, r=0, lora_alpha=1, lora_dropout=0.0, bias=True):
+        super().__init__(in_features, out_features, bias=bias)
+        self.r = r
+        if r > 0:
+            self.lora_A = nn.Linear(in_features, r, bias=False)
+            self.lora_B = nn.Linear(r, out_features, bias=False)
+            self.scaling = lora_alpha / r
+            self.lora_dropout = nn.Dropout(lora_dropout)
+            nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B.weight)
+        else:
+            self.lora_A = None
+            self.lora_B = None
+            self.lora_dropout = nn.Identity()
+
+    def forward(self, x):
+        result = super().forward(x)
+        if self.r > 0:
+            result = result + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
+        return result
+
+
+class SingLoRALinear(nn.Linear):
+    """Linear layer with Single-matrix LoRA (SingLoRA)."""
+
+    def __init__(self, in_features, out_features, r=0, alpha=1, dropout=0.0, bias=True):
+        super().__init__(in_features, out_features, bias=bias)
+        self.r = r
+        if r > 0:
+            dim = max(in_features, out_features)
+            self.singlora_A = nn.Parameter(torch.empty(dim, r))
+            nn.init.kaiming_uniform_(self.singlora_A, a=math.sqrt(5))
+            self.scaling = alpha / r
+            self.singlora_dropout = nn.Dropout(dropout)
+        else:
+            self.singlora_A = None
+            self.singlora_dropout = nn.Identity()
+        self.in_features = in_features
+        self.out_features = out_features
+
+    def forward(self, x):
+        result = super().forward(x)
+        if self.r > 0:
+            A_in = self.singlora_A[: self.in_features]
+            A_out = self.singlora_A[: self.out_features]
+            result = result + (self.singlora_dropout(x) @ A_in) @ A_out.t() * self.scaling
+        return result
+
 class LayerNorm(nn.Module):
     """ LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False """
 
@@ -31,10 +83,20 @@ class CausalSelfAttention(nn.Module):
     def __init__(self, config):
         super().__init__()
         assert config.n_embd % config.n_head == 0
+        if config.singlora_r > 0:
+            Linear = lambda in_f, out_f: SingLoRALinear(in_f, out_f, r=config.singlora_r,
+                                                       alpha=config.singlora_alpha,
+                                                       dropout=config.singlora_dropout,
+                                                       bias=config.bias)
+        else:
+            Linear = lambda in_f, out_f: LoRALinear(in_f, out_f, r=config.lora_r,
+                                                    lora_alpha=config.lora_alpha,
+                                                    lora_dropout=config.lora_dropout,
+                                                    bias=config.bias)
         # key, query, value projections for all heads, but in a batch
-        self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd, bias=config.bias)
+        self.c_attn = Linear(config.n_embd, 3 * config.n_embd)
         # output projection
-        self.c_proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
+        self.c_proj = Linear(config.n_embd, config.n_embd)
         # regularization
         self.attn_dropout = nn.Dropout(config.dropout)
         self.resid_dropout = nn.Dropout(config.dropout)
@@ -79,9 +141,19 @@ class MLP(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        self.c_fc    = nn.Linear(config.n_embd, 4 * config.n_embd, bias=config.bias)
+        if config.singlora_r > 0:
+            Linear = lambda in_f, out_f: SingLoRALinear(in_f, out_f, r=config.singlora_r,
+                                                       alpha=config.singlora_alpha,
+                                                       dropout=config.singlora_dropout,
+                                                       bias=config.bias)
+        else:
+            Linear = lambda in_f, out_f: LoRALinear(in_f, out_f, r=config.lora_r,
+                                                    lora_alpha=config.lora_alpha,
+                                                    lora_dropout=config.lora_dropout,
+                                                    bias=config.bias)
+        self.c_fc    = Linear(config.n_embd, 4 * config.n_embd)
         self.gelu    = nn.GELU()
-        self.c_proj  = nn.Linear(4 * config.n_embd, config.n_embd, bias=config.bias)
+        self.c_proj  = Linear(4 * config.n_embd, config.n_embd)
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x):
@@ -114,6 +186,12 @@ class GPTConfig:
     n_embd: int = 768
     dropout: float = 0.0
     bias: bool = True # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
+    lora_r: int = 0
+    lora_alpha: int = 1
+    lora_dropout: float = 0.0
+    singlora_r: int = 0
+    singlora_alpha: int = 1
+    singlora_dropout: float = 0.0
 
 class GPT(nn.Module):
 
@@ -121,6 +199,7 @@ class GPT(nn.Module):
         super().__init__()
         assert config.vocab_size is not None
         assert config.block_size is not None
+        assert not (config.lora_r > 0 and config.singlora_r > 0), "LoRA and SingLoRA are mutually exclusive"
         self.config = config
 
         self.transformer = nn.ModuleDict(dict(
@@ -207,8 +286,10 @@ class GPT(nn.Module):
     def from_pretrained(cls, model_type, override_args=None):
         assert model_type in {'gpt2', 'gpt2-medium', 'gpt2-large', 'gpt2-xl'}
         override_args = override_args or {} # default to empty dict
-        # only dropout can be overridden see more notes below
-        assert all(k == 'dropout' for k in override_args)
+        # allow overriding dropout and adapter hyperparameters
+        allowed_keys = {'dropout', 'lora_r', 'lora_alpha', 'lora_dropout',
+                        'singlora_r', 'singlora_alpha', 'singlora_dropout'}
+        assert all(k in allowed_keys for k in override_args)
         from transformers import GPT2LMHeadModel
         print("loading weights from pretrained gpt: %s" % model_type)
 
@@ -223,16 +304,19 @@ class GPT(nn.Module):
         config_args['vocab_size'] = 50257 # always 50257 for GPT model checkpoints
         config_args['block_size'] = 1024 # always 1024 for GPT model checkpoints
         config_args['bias'] = True # always True for GPT model checkpoints
-        # we can override the dropout rate, if desired
-        if 'dropout' in override_args:
-            print(f"overriding dropout rate to {override_args['dropout']}")
-            config_args['dropout'] = override_args['dropout']
+        # override dropout or adapter hyperparameters if provided
+        for k in ['dropout', 'lora_r', 'lora_alpha', 'lora_dropout',
+                  'singlora_r', 'singlora_alpha', 'singlora_dropout']:
+            if k in override_args:
+                print(f"overriding {k} to {override_args[k]}")
+                config_args[k] = override_args[k]
         # create a from-scratch initialized minGPT model
         config = GPTConfig(**config_args)
         model = GPT(config)
         sd = model.state_dict()
         sd_keys = sd.keys()
-        sd_keys = [k for k in sd_keys if not k.endswith('.attn.bias')] # discard this mask / buffer, not a param
+        sd_keys = [k for k in sd_keys if not k.endswith('.attn.bias')
+                   and 'lora_' not in k and 'singlora_' not in k] # discard mask/buffer and adapter params
 
         # init a huggingface/transformers model
         model_hf = GPT2LMHeadModel.from_pretrained(model_type)

--- a/train.py
+++ b/train.py
@@ -54,6 +54,12 @@ n_head = 12
 n_embd = 768
 dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
 bias = False # do we use bias inside LayerNorm and Linear layers?
+lora_r = 0
+lora_alpha = 1
+lora_dropout = 0.0
+singlora_r = 0
+singlora_alpha = 1
+singlora_dropout = 0.0
 # adamw optimizer
 learning_rate = 6e-4 # max learning rate
 max_iters = 600000 # total number of training iterations
@@ -76,6 +82,9 @@ compile = True # use PyTorch 2.0 to compile the model to be faster
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
 exec(open('configurator.py').read()) # overrides from command line or config file
 config = {k: globals()[k] for k in config_keys} # will be useful for logging
+# ensure adapter types are exclusive
+if lora_r > 0 and singlora_r > 0:
+    raise ValueError("LoRA and SingLoRA cannot be used together")
 # -----------------------------------------------------------------------------
 
 # various inits, derived attributes, I/O setup
@@ -145,7 +154,9 @@ if os.path.exists(meta_path):
 
 # model init
 model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,
-                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line
+                  bias=bias, vocab_size=None, dropout=dropout,
+                  lora_r=lora_r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+                  singlora_r=singlora_r, singlora_alpha=singlora_alpha, singlora_dropout=singlora_dropout) # start with model_args from command line
 if init_from == 'scratch':
     # init a new model from scratch
     print("Initializing a new model from scratch")
@@ -163,7 +174,9 @@ elif init_from == 'resume':
     checkpoint_model_args = checkpoint['model_args']
     # force these config attributes to be equal otherwise we can't even resume training
     # the rest of the attributes (e.g. dropout) can stay as desired from command line
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
+    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size',
+              'lora_r', 'lora_alpha', 'lora_dropout',
+              'singlora_r', 'singlora_alpha', 'singlora_dropout']:
         model_args[k] = checkpoint_model_args[k]
     # create the model
     gptconf = GPTConfig(**model_args)
@@ -181,16 +194,28 @@ elif init_from == 'resume':
 elif init_from.startswith('gpt2'):
     print(f"Initializing from OpenAI GPT-2 weights: {init_from}")
     # initialize from OpenAI GPT-2 weights
-    override_args = dict(dropout=dropout)
+    override_args = dict(dropout=dropout, lora_r=lora_r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+                         singlora_r=singlora_r, singlora_alpha=singlora_alpha, singlora_dropout=singlora_dropout)
     model = GPT.from_pretrained(init_from, override_args)
     # read off the created config params, so we can store them into checkpoint correctly
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
+    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size',
+              'lora_r', 'lora_alpha', 'lora_dropout',
+              'singlora_r', 'singlora_alpha', 'singlora_dropout']:
         model_args[k] = getattr(model.config, k)
 # crop down the model block size if desired, using model surgery
 if block_size < model.config.block_size:
     model.crop_block_size(block_size)
     model_args['block_size'] = block_size # so that the checkpoint will have the right value
 model.to(device)
+
+# freeze base model parameters if using adapters
+if lora_r > 0 or singlora_r > 0:
+    for name, param in model.named_parameters():
+        if 'lora_' not in name and 'singlora_' not in name:
+            param.requires_grad = False
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    mode = 'LoRA' if lora_r > 0 else 'SingLoRA'
+    print(f"{mode} enabled, trainable parameters: {trainable}")
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
 scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))


### PR DESCRIPTION
## Summary
- introduce SingLoRALinear and integrate into attention/MLP blocks
- extend GPTConfig, pretrained loading, and training script to support SingLoRA and enforce exclusivity with LoRA

## Testing
- `python -m pytest`
- `python - <<'PY'
from model import GPTConfig, GPT
import torch
cfg = GPTConfig(singlora_r=4, singlora_alpha=8, singlora_dropout=0.1)
m = GPT(cfg)
x = torch.randint(0, cfg.vocab_size, (1, 10))
logits, loss = m(x, x)
print('logits', logits.shape, 'loss', float(loss))
PY`
- `python - <<'PY'
from model import GPT
m = GPT.from_pretrained('gpt2', override_args={'singlora_r':4})
for name, p in m.named_parameters():
    if 'singlora_' not in name:
        p.requires_grad = False
trainable = sum(p.numel() for p in m.parameters() if p.requires_grad)
print('trainable params', trainable)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8ccdaddd48326ab133bdb80cd3d7e