### PR TITLE
Add LLaMA 3.1 model and LoRA fine-tuning support

### DIFF
--- a/llama_model.py
+++ b/llama_model.py
@@ -1,0 +1,85 @@
+"""Implementation of LLaMA 3.1 models with optional LoRA and SingLoRA adapters."""
+
+from dataclasses import dataclass
+import torch
+import torch.nn as nn
+from transformers import LlamaForCausalLM
+
+from lora import LoRALinear, SingLoRALinear
+
+
+@dataclass
+class LlamaConfig:
+    model_name: str
+    lora_r: int = 0
+    lora_alpha: int = 1
+    lora_dropout: float = 0.0
+    single_lora: bool = False
+
+
+PRETRAINED_LLAMA3_1 = {
+    "8B": "meta-llama/Meta-Llama-3.1-8B",
+    "70B": "meta-llama/Meta-Llama-3.1-70B",
+}
+
+
+class Llama3(nn.Module):
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.config = config
+        self.model = LlamaForCausalLM.from_pretrained(config.model_name)
+        if config.lora_r > 0 or config.single_lora:
+            self._inject_lora()
+
+    def _factory(self, in_features, out_features, bias=True):
+        if self.config.single_lora:
+            return SingLoRALinear(
+                in_features,
+                out_features,
+                r=self.config.lora_r,
+                alpha=self.config.lora_alpha,
+                dropout=self.config.lora_dropout,
+                bias=bias,
+            )
+        else:
+            return LoRALinear(
+                in_features,
+                out_features,
+                r=self.config.lora_r,
+                lora_alpha=self.config.lora_alpha,
+                lora_dropout=self.config.lora_dropout,
+                bias=bias,
+            )
+
+    def _convert_linear(self, module: nn.Linear) -> nn.Module:
+        new_linear = self._factory(
+            module.in_features, module.out_features, bias=module.bias is not None
+        )
+        new_linear.weight = module.weight
+        if module.bias is not None:
+            new_linear.bias = module.bias
+        return new_linear
+
+    def _inject_lora(self):
+        for layer in self.model.model.layers:
+            layer.self_attn.q_proj = self._convert_linear(layer.self_attn.q_proj)
+            layer.self_attn.k_proj = self._convert_linear(layer.self_attn.k_proj)
+            layer.self_attn.v_proj = self._convert_linear(layer.self_attn.v_proj)
+            layer.self_attn.o_proj = self._convert_linear(layer.self_attn.o_proj)
+            layer.mlp.gate_proj = self._convert_linear(layer.mlp.gate_proj)
+            layer.mlp.up_proj = self._convert_linear(layer.mlp.up_proj)
+            layer.mlp.down_proj = self._convert_linear(layer.mlp.down_proj)
+
+    def forward(self, input_ids, attention_mask=None, labels=None):
+        return self.model(
+            input_ids=input_ids, attention_mask=attention_mask, labels=labels
+        )
+
+    def configure_optimizers(self, weight_decay, learning_rate, betas, device_type):
+        return torch.optim.AdamW(self.parameters(), lr=learning_rate, betas=betas, weight_decay=weight_decay)
+
+    @classmethod
+    def from_pretrained(cls, size: str = "8B", **kwargs):
+        model_name = PRETRAINED_LLAMA3_1[size]
+        config = LlamaConfig(model_name=model_name, **kwargs)
+        return cls(config)

--- a/lora.py
+++ b/lora.py
@@ -1,0 +1,53 @@
+import math
+import torch
+import torch.nn as nn
+
+class LoRALinear(nn.Linear):
+    """Linear layer with Low-Rank Adaptation (LoRA)."""
+
+    def __init__(self, in_features, out_features, r=0, lora_alpha=1, lora_dropout=0.0, bias=True):
+        super().__init__(in_features, out_features, bias=bias)
+        self.r = r
+        if r > 0:
+            self.lora_A = nn.Linear(in_features, r, bias=False)
+            self.lora_B = nn.Linear(r, out_features, bias=False)
+            self.scaling = lora_alpha / r
+            self.lora_dropout = nn.Dropout(lora_dropout)
+            nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B.weight)
+        else:
+            self.lora_A = None
+            self.lora_B = None
+            self.lora_dropout = nn.Identity()
+
+    def forward(self, x):
+        result = super().forward(x)
+        if self.r > 0:
+            result = result + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
+        return result
+
+class SingLoRALinear(nn.Linear):
+    """Linear layer with Single-matrix LoRA (SingLoRA)."""
+
+    def __init__(self, in_features, out_features, r=0, alpha=1, dropout=0.0, bias=True):
+        super().__init__(in_features, out_features, bias=bias)
+        self.r = r
+        self.in_features = in_features
+        self.out_features = out_features
+        if r > 0:
+            dim = max(in_features, out_features)
+            self.singlora_A = nn.Parameter(torch.empty(dim, r))
+            nn.init.kaiming_uniform_(self.singlora_A, a=math.sqrt(5))
+            self.scaling = alpha / r
+            self.singlora_dropout = nn.Dropout(dropout)
+        else:
+            self.singlora_A = None
+            self.singlora_dropout = nn.Identity()
+
+    def forward(self, x):
+        result = super().forward(x)
+        if self.r > 0:
+            A_in = self.singlora_A[: self.in_features]
+            A_out = self.singlora_A[: self.out_features]
+            result = result + (self.singlora_dropout(x) @ A_in) @ A_out.t() * self.scaling
+        return result

--- a/model.py
+++ b/model.py
@@ -15,30 +15,7 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-
-class LoRALinear(nn.Linear):
-    """Linear layer with Low-Rank Adaptation (LoRA)."""
-
-    def __init__(self, in_features, out_features, r=0, lora_alpha=1, lora_dropout=0.0, bias=True):
-        super().__init__(in_features, out_features, bias=bias)
-        self.r = r
-        if r > 0:
-            self.lora_A = nn.Linear(in_features, r, bias=False)
-            self.lora_B = nn.Linear(r, out_features, bias=False)
-            self.scaling = lora_alpha / r
-            self.lora_dropout = nn.Dropout(lora_dropout)
-            nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
-            nn.init.zeros_(self.lora_B.weight)
-        else:
-            self.lora_A = None
-            self.lora_B = None
-            self.lora_dropout = nn.Identity()
-
-    def forward(self, x):
-        result = super().forward(x)
-        if self.r > 0:
-            result = result + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
-        return result
+from lora import LoRALinear
 
 class LayerNorm(nn.Module):
     """ LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False """

--- a/train_llama.py
+++ b/train_llama.py
@@ -1,0 +1,294 @@
+"""
+This training script can be run both on a single gpu in debug mode,
+and also in a larger training run with distributed data parallel (ddp).
+
+To run on a single GPU, example:
+$ python train.py --batch_size=32 --compile=False
+
+To run with DDP on 4 gpus on 1 node, example:
+$ torchrun --standalone --nproc_per_node=4 train.py
+
+To run with DDP on 4 gpus across 2 nodes, example:
+- Run on the first (master) node with example IP 123.456.123.456:
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py
+- Run on the worker node:
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
+(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
+"""
+
+import os
+import time
+import math
+import pickle
+from contextlib import nullcontext
+
+import numpy as np
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import init_process_group, destroy_process_group
+
+from llama_model import Llama3
+
+# -----------------------------------------------------------------------------
+# default config values designed to train a gpt2 (124M) on OpenWebText
+# I/O
+out_dir = 'out'
+eval_interval = 2000
+log_interval = 1
+eval_iters = 200
+eval_only = False # if True, script exits right after the first eval
+always_save_checkpoint = True # if True, always save a checkpoint after each eval
+# model
+model_size = '8B' # '8B' or '70B'
+dropout = 0.0
+bias = False
+lora_r = 0
+lora_alpha = 1
+lora_dropout = 0.0
+single_lora = False
+# wandb logging
+wandb_log = False # disabled by default
+wandb_project = 'owt'
+wandb_run_name = 'llama3' # 'run' + str(time.time())
+# data
+dataset = 'openwebtext'
+gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
+batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
+block_size = 1024
+# adamw optimizer
+learning_rate = 6e-4 # max learning rate
+max_iters = 600000 # total number of training iterations
+weight_decay = 1e-1
+beta1 = 0.9
+beta2 = 0.95
+grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0
+# learning rate decay settings
+decay_lr = True # whether to decay the learning rate
+warmup_iters = 2000 # how many steps to warm up for
+lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
+min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
+# DDP settings
+backend = 'nccl' # 'nccl', 'gloo', etc.
+# system
+device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
+dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
+compile = True # use PyTorch 2.0 to compile the model to be faster
+# -----------------------------------------------------------------------------
+config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
+exec(open('configurator.py').read()) # overrides from command line or config file
+config = {k: globals()[k] for k in config_keys} # will be useful for logging
+# -----------------------------------------------------------------------------
+
+# various inits, derived attributes, I/O setup
+ddp = int(os.environ.get('RANK', -1)) != -1 # is this a ddp run?
+if ddp:
+    init_process_group(backend=backend)
+    ddp_rank = int(os.environ['RANK'])
+    ddp_local_rank = int(os.environ['LOCAL_RANK'])
+    ddp_world_size = int(os.environ['WORLD_SIZE'])
+    device = f'cuda:{ddp_local_rank}'
+    torch.cuda.set_device(device)
+    master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
+    seed_offset = ddp_rank # each process gets a different seed
+    # world_size number of processes will be training simultaneously, so we can scale
+    # down the desired gradient accumulation iterations per process proportionally
+    assert gradient_accumulation_steps % ddp_world_size == 0
+    gradient_accumulation_steps //= ddp_world_size
+else:
+    # if not ddp, we are running on a single gpu, and one process
+    master_process = True
+    seed_offset = 0
+    ddp_world_size = 1
+tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size
+print(f"tokens per iteration will be: {tokens_per_iter:,}")
+
+if master_process:
+    os.makedirs(out_dir, exist_ok=True)
+torch.manual_seed(1337 + seed_offset)
+torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
+torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
+device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+# note: float16 data type will automatically use a GradScaler
+ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
+ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
+# poor man's data loader
+data_dir = os.path.join('data', dataset)
+def get_batch(split):
+    # We recreate np.memmap every batch to avoid a memory leak, as per
+    # https://stackoverflow.com/questions/45132940/numpy-memmap-memory-usage-want-to-iterate-once/61472122#61472122
+    if split == 'train':
+        data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
+    else:
+        data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
+    ix = torch.randint(len(data) - block_size, (batch_size,))
+    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
+    y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
+    if device_type == 'cuda':
+        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
+        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
+    else:
+        x, y = x.to(device), y.to(device)
+    return x, y
+
+# init iteration and best validation loss
+iter_num = 0
+best_val_loss = 1e9
+
+# model init
+print(f"Initializing LLaMA3 {model_size}")
+model = Llama3.from_pretrained(
+    size=model_size,
+    lora_r=lora_r,
+    lora_alpha=lora_alpha,
+    lora_dropout=lora_dropout,
+    single_lora=single_lora,
+)
+model.to(device)
+
+# freeze base model parameters if using LoRA or SingLoRA
+if lora_r > 0 or single_lora:
+    for name, param in model.named_parameters():
+        if 'lora_' not in name:
+            param.requires_grad = False
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(f"LoRA enabled, trainable parameters: {trainable}")
+
+# initialize a GradScaler. If enabled=False scaler is a no-op
+scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+
+# optimizer
+optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)
+
+# compile the model
+if compile:
+    print("compiling the model... (takes a ~minute)")
+    unoptimized_model = model
+    model = torch.compile(model) # requires PyTorch 2.0
+
+# wrap model into DDP container
+if ddp:
+    model = DDP(model, device_ids=[ddp_local_rank])
+
+# helps estimate an arbitrarily accurate loss over either split using many batches
+@torch.no_grad()
+def estimate_loss():
+    out = {}
+    model.eval()
+    for split in ['train', 'val']:
+        losses = torch.zeros(eval_iters)
+        for k in range(eval_iters):
+            X, Y = get_batch(split)
+            with ctx:
+                logits, loss = model(X, Y)
+            losses[k] = loss.item()
+        out[split] = losses.mean()
+    model.train()
+    return out
+
+# learning rate decay scheduler (cosine with warmup)
+def get_lr(it):
+    # 1) linear warmup for warmup_iters steps
+    if it < warmup_iters:
+        return learning_rate * (it + 1) / (warmup_iters + 1)
+    # 2) if it > lr_decay_iters, return min learning rate
+    if it > lr_decay_iters:
+        return min_lr
+    # 3) in between, use cosine decay down to min learning rate
+    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    assert 0 <= decay_ratio <= 1
+    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1
+    return min_lr + coeff * (learning_rate - min_lr)
+
+# logging
+if wandb_log and master_process:
+    import wandb
+    wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+
+# training loop
+X, Y = get_batch('train') # fetch the very first batch
+t0 = time.time()
+local_iter_num = 0 # number of iterations in the lifetime of this process
+raw_model = model.module if ddp else model # unwrap DDP container if needed
+running_mfu = -1.0
+while True:
+
+    # determine and set the learning rate for this iteration
+    lr = get_lr(iter_num) if decay_lr else learning_rate
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = lr
+
+    # evaluate the loss on train/val sets and write checkpoints
+    if iter_num % eval_interval == 0 and master_process:
+        losses = estimate_loss()
+        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+        if wandb_log:
+            wandb.log({
+                "iter": iter_num,
+                "train/loss": losses['train'],
+                "val/loss": losses['val'],
+                "lr": lr,
+                "mfu": running_mfu*100, # convert to percentage
+            })
+        if losses['val'] < best_val_loss or always_save_checkpoint:
+            best_val_loss = losses['val']
+            if iter_num > 0:
+                checkpoint = {
+                    'model': raw_model.state_dict(),
+                    'optimizer': optimizer.state_dict(),
+                    'iter_num': iter_num,
+                    'best_val_loss': best_val_loss,
+                    'config': config,
+                }
+                print(f"saving checkpoint to {out_dir}")
+                torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+    if iter_num == 0 and eval_only:
+        break
+
+    # forward backward update, with optional gradient accumulation to simulate larger batch size
+    # and using the GradScaler if data type is float16
+    for micro_step in range(gradient_accumulation_steps):
+        if ddp:
+            # in DDP training we only need to sync gradients at the last micro step.
+            # the official way to do this is with model.no_sync() context manager, but
+            # I really dislike that this bloats the code and forces us to repeat code
+            # looking at the source of that context manager, it just toggles this variable
+            model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
+        with ctx:
+            logits, loss = model(X, Y)
+            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation
+        # immediately async prefetch next batch while model is doing the forward pass on the GPU
+        X, Y = get_batch('train')
+        # backward pass, with gradient scaling if training in fp16
+        scaler.scale(loss).backward()
+    # clip the gradient
+    if grad_clip != 0.0:
+        scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+    # step the optimizer and scaler if training in fp16
+    scaler.step(optimizer)
+    scaler.update()
+    # flush the gradients as soon as we can, no need for this memory anymore
+    optimizer.zero_grad(set_to_none=True)
+
+    # timing and logging
+    t1 = time.time()
+    dt = t1 - t0
+    t0 = t1
+    if iter_num % log_interval == 0 and master_process:
+        # get loss as float. note: this is a CPU-GPU sync point
+        # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
+        lossf = loss.item() * gradient_accumulation_steps
+        if local_iter_num >= 5: # let the training loop settle a bit
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
+        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
+    iter_num += 1
+    local_iter_num += 1
+
+    # termination conditions
+    if iter_num > max_iters:
+        break
+
+if ddp:
+    destroy_process_group()


### PR DESCRIPTION
## Summary
- factor LoRA utilities into `lora.py` and add single-matrix SingLoRA variant
- implement `llama_model.py` to load LLaMA 3.1 weights with optional LoRA or SingLoRA adapters
- add `train_llama.py` script for fine-tuning pretrained LLaMA 3.1 8B/70B models
- correct previous SingleLoRA implementation to match SingLoRA paper

## Testing
- `python -m py_compile lora.py llama_model.py train_llama.py`


------
https://chatgpt.com/codex/tasks/task_e_68be0dae7dd88326a2cee59eb4ddc2ac