### PR TITLE
Add Llama 3.1 fine-tuning with LoRA adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,20 @@ python train_llama.py --config=config/finetune_llama3_lora.py
 ```
 
 Set `init_from` in the config to `"meta-llama/Llama-3.1-70B"` to target the 70B model.
+
+### Instruction-tuning datasets
+
+Several supervised fine-tuning (SFT) corpora can be converted into the
+binary format expected by `train_llama.py` via the helper script
+`data/sft/prepare.py`. It downloads a dataset, formats each
+instruction/response pair with the tokenizer's chat template and writes
+`train.bin`/`val.bin` into `data/<dataset>/`.
+
+Example for the Tulu personas dataset:
+
+```sh
+python data/sft/prepare.py --dataset tulu
+python train_llama.py --config=config/finetune_llama3_lora.py --dataset=tulu
+```
+
+Other supported values for `--dataset` are `ifeval` and `autoif`.

--- a/README.md
+++ b/README.md
@@ -225,3 +225,15 @@ For more questions/discussions feel free to stop by **#nanoGPT** on Discord:
 ## acknowledgements
 
 All nanoGPT experiments are powered by GPUs on [Lambda labs](https://lambdalabs.com), my favorite Cloud GPU provider. Thank you Lambda labs for sponsoring nanoGPT!
+
+## Llama 3.1 fine-tuning
+
+Support for Meta's [Llama 3.1](https://huggingface.co/meta-llama) models has been added via the `llama_model.py` and `train_llama.py` scripts. Pretrained checkpoints (8B or 70B) are loaded from Hugging Face and LoRA or SingLoRA adapters can be applied for efficient fine-tuning. The adapters swap in for every linear layer in the Hugging Face model and are zero-initialized, so wrapping a checkpoint leaves its initial forward pass unchanged.
+
+Example usage:
+
+```sh
+python train_llama.py --config=config/finetune_llama3_lora.py
+```
+
+Set `init_from` in the config to `"meta-llama/Llama-3.1-70B"` to target the 70B model.

--- a/config/finetune_llama3_lora.py
+++ b/config/finetune_llama3_lora.py
@@ -1,0 +1,11 @@
+# Configuration for fine-tuning Llama 3.1 with LoRA adapters
+out_dir = 'out-llama3'
+init_from = 'meta-llama/Llama-3.1-8B'
+block_size = 4096
+batch_size = 4
+learning_rate = 3e-4
+max_iters = 1000
+lora_r = 8
+lora_alpha = 16
+lora_dropout = 0.05
+# set singlora_r > 0 instead of lora_r to use SingLoRA

--- a/data/sft/prepare.py
+++ b/data/sft/prepare.py
@@ -1,0 +1,89 @@
+import os
+import argparse
+import pickle
+from typing import List, Dict
+
+import numpy as np
+from datasets import load_dataset
+from transformers import AutoTokenizer
+from tqdm import tqdm
+
+# Mapping from short names to Hugging Face hub identifiers
+HF_DATASETS = {
+    "tulu": "allenai/tulu-3-sft-personas-instruction-following",
+    "ifeval": "argilla/ifeval-like-data",
+    "autoif": "Post-training-Data-Flywheel/AutoIF-instruct-61k-with-funcs",
+}
+
+
+def build_messages(name: str, example: Dict) -> List[Dict[str, str]]:
+    """Return a chat-style list of messages for different dataset formats."""
+    if name == "tulu":
+        messages = example["messages"]
+    elif name == "ifeval":
+        messages = [
+            {"role": "user", "content": example["instruction"]},
+            {"role": "assistant", "content": example["response"]},
+        ]
+    elif name == "autoif":
+        messages = example["messages"]
+        system = example.get("system")
+        if system:
+            messages = [{"role": "system", "content": system}] + messages
+    else:
+        raise ValueError(f"unknown dataset name: {name}")
+    return messages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare SFT datasets for nanoGPT")
+    parser.add_argument("--dataset", choices=HF_DATASETS.keys(), required=True,
+                        help="which dataset to prepare")
+    parser.add_argument("--model", default="meta-llama/Llama-3.1-8B",
+                        help="tokenizer name")
+    parser.add_argument("--val_split", type=float, default=0.02,
+                        help="fraction of examples for validation")
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    dataset = load_dataset(HF_DATASETS[args.dataset])
+    split = dataset["train"].train_test_split(test_size=args.val_split,
+                                              seed=2357, shuffle=True)
+    split["val"] = split.pop("test")
+
+    def tokenize(example: Dict) -> Dict:
+        ids = tokenizer.apply_chat_template(
+            build_messages(args.dataset, example),
+            tokenize=True,
+            add_generation_prompt=False,
+        )
+        ids.append(tokenizer.eos_token_id)
+        return {"ids": ids, "len": len(ids)}
+
+    remove_cols = dataset["train"].column_names
+    tokenized = split.map(tokenize, remove_columns=remove_cols,
+                          desc="tokenizing", num_proc=4)
+
+    out_dir = os.path.join(os.path.dirname(__file__), args.dataset)
+    os.makedirs(out_dir, exist_ok=True)
+
+    vocab_size = tokenizer.vocab_size
+    dtype = np.uint16 if vocab_size <= np.iinfo(np.uint16).max else np.uint32
+
+    for part, dset in tokenized.items():
+        arr_len = np.sum(dset["len"], dtype=np.uint64)
+        filename = os.path.join(out_dir, f"{part}.bin")
+        arr = np.memmap(filename, dtype=dtype, mode="w+", shape=(arr_len,))
+        idx = 0
+        for ids in tqdm(dset["ids"], desc=f"writing {filename}"):
+            arr[idx:idx + len(ids)] = ids
+            idx += len(ids)
+        arr.flush()
+
+    meta = {"vocab_size": vocab_size}
+    with open(os.path.join(out_dir, "meta.pkl"), "wb") as f:
+        pickle.dump(meta, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/llama_model.py
+++ b/llama_model.py
@@ -1,0 +1,47 @@
+import torch
+import torch.nn as nn
+from transformers import LlamaForCausalLM
+from model import LoRALinear, SingLoRALinear
+
+
+def _replace_linear(module: nn.Module,
+                    lora_r: int, lora_alpha: int, lora_dropout: float,
+                    singlora_r: int, singlora_alpha: int, singlora_dropout: float):
+    """Recursively replace nn.Linear layers with LoRA/SingLoRA versions."""
+    for name, child in module.named_children():
+        if isinstance(child, nn.Linear):
+            bias = child.bias is not None
+            if singlora_r > 0:
+                new_module = SingLoRALinear(child.in_features, child.out_features,
+                                            r=singlora_r, alpha=singlora_alpha,
+                                            dropout=singlora_dropout, bias=bias)
+            else:
+                new_module = LoRALinear(child.in_features, child.out_features,
+                                        r=lora_r, lora_alpha=lora_alpha,
+                                        lora_dropout=lora_dropout, bias=bias)
+            new_module = new_module.to(child.weight.device, dtype=child.weight.dtype)
+            new_module.weight = child.weight
+            if child.bias is not None:
+                new_module.bias = child.bias
+            setattr(module, name, new_module)
+        else:
+            _replace_linear(child, lora_r, lora_alpha, lora_dropout,
+                            singlora_r, singlora_alpha, singlora_dropout)
+
+
+def load_pretrained_llama(model_name: str,
+                           lora_r: int = 0,
+                           lora_alpha: int = 1,
+                           lora_dropout: float = 0.0,
+                           singlora_r: int = 0,
+                           singlora_alpha: int = 1,
+                           singlora_dropout: float = 0.0,
+                           device: str = 'cuda',
+                           dtype: str = 'bfloat16'):
+    """Load a pretrained Llama model and optionally enable LoRA/SingLoRA."""
+    model = LlamaForCausalLM.from_pretrained(model_name, torch_dtype=getattr(torch, dtype))
+    model.to(device)
+    if lora_r > 0 or singlora_r > 0:
+        _replace_linear(model, lora_r, lora_alpha, lora_dropout,
+                        singlora_r, singlora_alpha, singlora_dropout)
+    return model

--- a/model.py
+++ b/model.py
@@ -49,8 +49,9 @@ class SingLoRALinear(nn.Linear):
         self.r = r
         if r > 0:
             dim = max(in_features, out_features)
-            self.singlora_A = nn.Parameter(torch.empty(dim, r))
-            nn.init.kaiming_uniform_(self.singlora_A, a=math.sqrt(5))
+            # initialize to zeros so that injecting SingLoRA leaves
+            # the pretrained model's forward pass unchanged
+            self.singlora_A = nn.Parameter(torch.zeros(dim, r))
             self.scaling = alpha / r
             self.singlora_dropout = nn.Dropout(dropout)
         else:

--- a/train_llama.py
+++ b/train_llama.py
@@ -109,8 +109,9 @@ if os.path.exists(meta_path):
     print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
 
 data_dir = os.path.join('data', dataset)
-train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
-val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
+data_dtype = np.uint16 if (meta_vocab_size or 0) <= np.iinfo(np.uint16).max else np.uint32
+train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=data_dtype, mode='r')
+val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=data_dtype, mode='r')
 
 def get_batch(split):
     data = train_data if split == 'train' else val_data

--- a/train_llama.py
+++ b/train_llama.py
@@ -1,0 +1,204 @@
+"""
+Training script for fine-tuning Llama 3.1 models with LoRA or SingLoRA adapters.
+The script follows the minimal style of nanoGPT's train.py but uses HuggingFace
+Transformers to load the pretrained Llama models.
+"""
+
+import os
+import time
+import math
+import pickle
+from contextlib import nullcontext
+
+import numpy as np
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import init_process_group, destroy_process_group
+
+from llama_model import load_pretrained_llama
+
+# -----------------------------------------------------------------------------
+# default config values
+out_dir = 'out'
+eval_interval = 2000
+log_interval = 1
+eval_iters = 200
+eval_only = False
+always_save_checkpoint = True
+init_from = 'meta-llama/Llama-3.1-8B'  # or 'meta-llama/Llama-3.1-70B'
+wandb_log = False
+wandb_project = 'llama3'
+wandb_run_name = 'llama3_finetune'
+
+dataset = 'openwebtext'
+gradient_accumulation_steps = 5 * 8
+batch_size = 12
+block_size = 4096
+
+dropout = 0.0
+bias = False
+lora_r = 0
+lora_alpha = 1
+lora_dropout = 0.0
+singlora_r = 0
+singlora_alpha = 1
+singlora_dropout = 0.0
+
+learning_rate = 3e-4
+max_iters = 10000
+weight_decay = 1e-1
+beta1 = 0.9
+beta2 = 0.95
+grad_clip = 1.0
+
+decay_lr = True
+warmup_iters = 100
+lr_decay_iters = max_iters
+min_lr = 1e-5
+
+backend = 'nccl'
+device = 'cuda'
+dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16'
+compile = True
+# -----------------------------------------------------------------------------
+config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
+exec(open('configurator.py').read())
+config = {k: globals()[k] for k in config_keys}
+if lora_r > 0 and singlora_r > 0:
+    raise ValueError('LoRA and SingLoRA cannot be used together')
+# -----------------------------------------------------------------------------
+
+# ddp setup
+ddp = int(os.environ.get('RANK', -1)) != -1
+if ddp:
+    init_process_group(backend=backend)
+    ddp_rank = int(os.environ['RANK'])
+    ddp_local_rank = int(os.environ['LOCAL_RANK'])
+    ddp_world_size = int(os.environ['WORLD_SIZE'])
+    device = f'cuda:{ddp_local_rank}'
+    torch.cuda.set_device(device)
+    master_process = ddp_rank == 0
+    seed_offset = ddp_rank
+    assert gradient_accumulation_steps % ddp_world_size == 0
+    gradient_accumulation_steps //= ddp_world_size
+else:
+    master_process = True
+    seed_offset = 0
+    ddp_world_size = 1
+
+tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size
+print(f"tokens per iteration will be: {tokens_per_iter:,}")
+
+if master_process:
+    os.makedirs(out_dir, exist_ok=True)
+
+torch.manual_seed(1337 + seed_offset)
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+device_type = 'cuda' if 'cuda' in device else 'cpu'
+ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
+ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
+# data loader
+meta_path = os.path.join('data', dataset, 'meta.pkl')
+meta_vocab_size = None
+if os.path.exists(meta_path):
+    with open(meta_path, 'rb') as f:
+        meta = pickle.load(f)
+    meta_vocab_size = meta['vocab_size']
+    print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
+
+data_dir = os.path.join('data', dataset)
+train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
+val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
+
+def get_batch(split):
+    data = train_data if split == 'train' else val_data
+    ix = torch.randint(len(data) - block_size, (batch_size,))
+    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
+    y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
+    if device_type == 'cuda':
+        x = x.pin_memory().to(device, non_blocking=True)
+        y = y.pin_memory().to(device, non_blocking=True)
+    else:
+        x, y = x.to(device), y.to(device)
+    return x, y
+
+# model init
+model = load_pretrained_llama(init_from,
+                              lora_r=lora_r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+                              singlora_r=singlora_r, singlora_alpha=singlora_alpha, singlora_dropout=singlora_dropout,
+                              device=device, dtype=dtype)
+
+if lora_r > 0 or singlora_r > 0:
+    for name, param in model.named_parameters():
+        if 'lora_' not in name and 'singlora_' not in name:
+            param.requires_grad = False
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    mode = 'LoRA' if lora_r > 0 else 'SingLoRA'
+    print(f"{mode} enabled, trainable parameters: {trainable}")
+
+scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+optimizer = torch.optim.AdamW(filter(lambda p: p.requires_grad, model.parameters()), lr=learning_rate, betas=(beta1, beta2), weight_decay=weight_decay)
+
+if compile:
+    print('compiling the model... (takes a ~minute)')
+    unoptimized_model = model
+    model = torch.compile(model)
+
+if ddp:
+    model = DDP(model, device_ids=[ddp_local_rank])
+
+@torch.no_grad()
+def estimate_loss():
+    out = {}
+    model.eval()
+    for split in ['train', 'val']:
+        losses = torch.zeros(eval_iters)
+        for k in range(eval_iters):
+            X, Y = get_batch(split)
+            with ctx:
+                logits = model(X).logits
+                loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), Y.view(-1))
+            losses[k] = loss.item()
+        out[split] = losses.mean()
+    model.train()
+    return out
+
+iter_num = 0
+best_val_loss = 1e9
+
+while True:
+    if iter_num % eval_interval == 0:
+        losses = estimate_loss()
+        if master_process:
+            print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+            if losses['val'] < best_val_loss or always_save_checkpoint:
+                best_val_loss = losses['val']
+                checkpoint = {
+                    'model': model.state_dict(),
+                    'optimizer': optimizer.state_dict(),
+                    'iter_num': iter_num,
+                    'best_val_loss': best_val_loss,
+                    'config': config,
+                }
+                torch.save(checkpoint, os.path.join(out_dir, 'llama3_ckpt.pt'))
+    if iter_num == max_iters:
+        break
+
+    for micro_step in range(gradient_accumulation_steps):
+        X, Y = get_batch('train')
+        with ctx:
+            logits = model(X).logits
+            loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), Y.view(-1)) / gradient_accumulation_steps
+        scaler.scale(loss).backward()
+    if grad_clip != 0.0:
+        scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+    scaler.step(optimizer)
+    scaler.update()
+    optimizer.zero_grad(set_to_none=True)
+    iter_num += 1
+
+if ddp:
+    destroy_process_group()


### PR DESCRIPTION
## Summary
- inject LoRA or SingLoRA adapters into all Hugging Face linear layers while preserving device and dtype
- zero-initialize SingLoRA weights so wrapping checkpoints leaves logits unchanged
- document adapter zero-init and compatibility with HuggingFace Llama 3.1 models

## Testing
- `python -m py_compile model.py llama_model.py train_llama.py config/finetune_llama3_lora.py`
- `python - <<'PY'
from llama_model import load_pretrained_llama
from transformers import LlamaForCausalLM
import torch

model_id = 'hf-internal-testing/tiny-random-LlamaForCausalLM'

base = LlamaForCausalLM.from_pretrained(model_id)
base.eval()
x = torch.randint(0, base.config.vocab_size, (1, 4))
with torch.no_grad():
    out_base = base(x).logits

lora_model = load_pretrained_llama(model_id, lora_r=4, device='cpu', dtype='float32')
lora_model.eval()
with torch.no_grad():
    out_lora = lora_model(x).logits

sing_model = load_pretrained_llama(model_id, singlora_r=4, device='cpu', dtype='float32')
sing_model.eval()
with torch.no_grad():
    out_sing = sing_model(x).logits

print('max diff lora', (out_base - out_lora).abs().max().item())
print('max diff singlora', (out_base - out_sing).abs().max().item())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be1430018083269e0dd07ebbb99276