### PR TITLE
Add SFT dataset preparation and flexible token dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,22 @@ python train_llama.py --config=config/finetune_llama3_lora.py
 ```
 
 Set `init_from` in the config to `"meta-llama/Llama-3.1-70B"` to target the 70B model.
+
+### Instruction-tuning datasets
+
+Several supervised fine-tuning (SFT) corpora can be converted into the
+binary format expected by `train_llama.py` via the helper script
+`data/sft/prepare.py`. It downloads a dataset, formats each
+instruction/response pair with the tokenizer's chat template and writes
+`train.bin`/`val.bin` into `data/<dataset>/`, so the dataset can be
+referenced directly via `--dataset <dataset>` when calling
+`train_llama.py`.
+
+Example for the Tulu personas dataset:
+
+```sh
+python data/sft/prepare.py --dataset tulu
+python train_llama.py --config=config/finetune_llama3_lora.py --dataset=tulu
+```
+
+Other supported values for `--dataset` are `ifeval` and `autoif`.

--- a/data/sft/prepare.py
+++ b/data/sft/prepare.py
@@ -1,0 +1,90 @@
+import os
+import argparse
+import pickle
+from typing import List, Dict
+
+import numpy as np
+from datasets import load_dataset
+from transformers import AutoTokenizer
+from tqdm import tqdm
+
+# Mapping from short names to Hugging Face hub identifiers
+HF_DATASETS = {
+    "tulu": "allenai/tulu-3-sft-personas-instruction-following",
+    "ifeval": "argilla/ifeval-like-data",
+    "autoif": "Post-training-Data-Flywheel/AutoIF-instruct-61k-with-funcs",
+}
+
+
+def build_messages(name: str, example: Dict) -> List[Dict[str, str]]:
+    """Return a chat-style list of messages for different dataset formats."""
+    if name == "tulu":
+        messages = example["messages"]
+    elif name == "ifeval":
+        messages = [
+            {"role": "user", "content": example["instruction"]},
+            {"role": "assistant", "content": example["response"]},
+        ]
+    elif name == "autoif":
+        messages = example["messages"]
+        system = example.get("system")
+        if system:
+            messages = [{"role": "system", "content": system}] + messages
+    else:
+        raise ValueError(f"unknown dataset name: {name}")
+    return messages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare SFT datasets for nanoGPT")
+    parser.add_argument("--dataset", choices=HF_DATASETS.keys(), required=True,
+                        help="which dataset to prepare")
+    parser.add_argument("--model", default="meta-llama/Llama-3.1-8B",
+                        help="tokenizer name")
+    parser.add_argument("--val_split", type=float, default=0.02,
+                        help="fraction of examples for validation")
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    dataset = load_dataset(HF_DATASETS[args.dataset])
+    split = dataset["train"].train_test_split(test_size=args.val_split,
+                                              seed=2357, shuffle=True)
+    split["val"] = split.pop("test")
+
+    def tokenize(example: Dict) -> Dict:
+        ids = tokenizer.apply_chat_template(
+            build_messages(args.dataset, example),
+            tokenize=True,
+            add_generation_prompt=False,
+        )
+        ids.append(tokenizer.eos_token_id)
+        return {"ids": ids, "len": len(ids)}
+
+    remove_cols = dataset["train"].column_names
+    tokenized = split.map(tokenize, remove_columns=remove_cols,
+                          desc="tokenizing", num_proc=4)
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    out_dir = os.path.join(os.path.dirname(script_dir), args.dataset)
+    os.makedirs(out_dir, exist_ok=True)
+
+    vocab_size = tokenizer.vocab_size
+    dtype = np.uint16 if vocab_size <= np.iinfo(np.uint16).max else np.uint32
+
+    for part, dset in tokenized.items():
+        arr_len = np.sum(dset["len"], dtype=np.uint64)
+        filename = os.path.join(out_dir, f"{part}.bin")
+        arr = np.memmap(filename, dtype=dtype, mode="w+", shape=(arr_len,))
+        idx = 0
+        for ids in tqdm(dset["ids"], desc=f"writing {filename}"):
+            arr[idx:idx + len(ids)] = ids
+            idx += len(ids)
+        arr.flush()
+
+    meta = {"vocab_size": vocab_size}
+    with open(os.path.join(out_dir, "meta.pkl"), "wb") as f:
+        pickle.dump(meta, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_llama.py
+++ b/train_llama.py
@@ -109,8 +109,9 @@ if os.path.exists(meta_path):
     print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
 
 data_dir = os.path.join('data', dataset)
-train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
-val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
+data_dtype = np.uint16 if (meta_vocab_size or 0) <= np.iinfo(np.uint16).max else np.uint32
+train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=data_dtype, mode='r')
+val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=data_dtype, mode='r')
 
 def get_batch(split):
     data = train_data if split == 'train' else val_data


### PR DESCRIPTION
## Summary
- add generic `data/sft/prepare.py` to convert several HF instruction-tuning datasets into train/val binaries using the model's chat template
- teach `train_llama.py` to select uint16 or uint32 memmaps based on vocab size
- document new SFT datasets and helper script in README
- write SFT binaries to `data/<dataset>/` so `train_llama.py --dataset <name>` works

## Testing
- `python -m py_compile data/sft/prepare.py train_llama.py`


------
https://chatgpt.com/codex/tasks/task_e_68be1b0da19083268a7c28720b6d7f64